### PR TITLE
tune.py: Add win adjudication option

### DIFF
--- a/tools/tune.py
+++ b/tools/tune.py
@@ -18,6 +18,9 @@ import chess
 import numpy as np
 import skopt
 
+
+MATE_SCORE = 32767
+
 warnings.filterwarnings(
     'ignore',
     message='The objective has been evaluated at this point before.')
@@ -218,7 +221,7 @@ async def get_value(context, init_board, args, game_id, adj_count, adj_score):
                                           f' {play.info.get("time",0)}s')
                 # Adjudicate game by score, save score in wpov
                 try:
-                    score_hist.append(play.info['score'].white().score(mate_score=32000))
+                    score_hist.append(play.info['score'].white().score(mate_score=MATE_SCORE))
                 except KeyError:
                     logging.debug(play.info)
                     logging.exception('Engine info line has no score.')

--- a/tools/tune.py
+++ b/tools/tune.py
@@ -219,6 +219,10 @@ async def get_value(context, init_board, args, game_id, adj_count, adj_score):
                 # Adjudicate game by score, save score in wpov
                 try:
                     score_hist.append(play.info['score'].white().score(mate_score=32000))
+                except KeyError:
+                    logging.debug(play.info)
+                    logging.exception('Engine info line has no score.')
+                    score_hist.append(0)
                 except Exception:
                     logging.debug(play.info)
                     logging.exception('Unexpected exception')

--- a/tools/tune.py
+++ b/tools/tune.py
@@ -221,7 +221,8 @@ async def get_value(context, init_board, args, game_id, adj_count, adj_score):
                                           f' {play.info.get("time",0)}s')
                 # Adjudicate game by score, save score in wpov
                 try:
-                    score_hist.append(play.info['score'].white().score(mate_score=MATE_SCORE))
+                    score_hist.append(play.info['score'].white().score(
+                            mate_score=max(adj_score, MATE_SCORE)))
                 except KeyError:
                     logging.debug(play.info)
                     logging.exception('Engine info line has no score.')

--- a/tools/tune.py
+++ b/tools/tune.py
@@ -87,7 +87,7 @@ group.add_argument('-acq-noise', default='gaussian', metavar='VAR',
 group = parser.add_argument_group('Adjudication options')
 group.add_argument('-win-adj', nargs='*',
                    help='Adjudicate won game. Usage: ' +
-                   f'-win-adj count=4 score=400 ' +
+                   '-win-adj count=4 score=400 ' +
                    f'Default values: count=4, score={MATE_SCORE}')
 
 


### PR DESCRIPTION
tune.py -h
```
...
Adjudication options:
  -win-adj [WIN_ADJ [WIN_ADJ ...]]
                        Adjudicate won game. Usage: -win-adj count=4 score=400
                        Default values: count=4, score=32767

```
Usage:
`-win-adj count=6 score=600`

6 refers to number of moves for each side, and 600 is the value in centi pawn.

When the last 6 moves of white is 600 or more and the last 6 moves of black is -600 or less then a game will be adjudicated as win for white. If conditions are reversed black would win.

It is also possible to just use
`-win-adj count=6`
or
`-win-adj score=600`
default values will be used for unspecified option.

Two sample games with count=3 and score=300
```
[Event "Tune.py"]
[Round "815"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "0-1"]
[BlackArgs "{'PawnValueEn': 120, 'KnightValueOp': 342, 'BishopValueOp': 287, 'RookValueOp': 507, 'QueenValueOp': 1030}"]
[Termination "adjudication based on score"]
[WhiteArgs "{}"]

1. d4 { book } 1... d5 { book } 2. c4 { book } 2... c6 { book } 3. Nc3 { book } 3... e6 { book } 4. e4 { book } 4... Bb4 { book } 5. Bd2 { book } 5... dxc4 { book } 6. Nf3 { +47/8 0.063s } 6... b5 { 0/8 0.063s } 7. a4 { +45/10 0.062s } 7... Bxc3 { -29/9 0.063s } 8. bxc3 { +82/9 0.062s } 8... Nf6 { -16/9 0.062s } 9. Qb1 { +129/9 0.063s } 9... Bd7 { -37/9 0.062s } 10. Bf4 { +106/9 0.063s } 10... Qe7 { -50/8 0.062s } 11. Be2 { +146/9 0.062s } 11... O-O { -47/9 0.063s } 12. O-O { +128/10 0.062s } 12... h6 { -56/8 0.063s } 13. h3 { +136/9 0.062s } 13... a5 { -68/8 0.062s } 14. Qc2 { +148/8 0.063s } 14... c5 { -82/8 0.062s } 15. axb5 { +225/7 0.063s } 15... Bxb5 { -66/10 0.062s } 16. dxc5 { +143/9 0.062s } 16... Qxc5 { -25/10 0.063s } 17. Rfd1 { +143/11 0.062s } 17... Bc6 { -97/8 0.062s } 18. Bd6 { +158/10 0.063s } 18... Bxe4 { -133/11 0.062s } 19. Qd2 { +102/10 0.062s } 19... Qc8 { -80/11 0.063s } 20. Bxf8 { +73/9 0.062s } 20... Qxf8 { -70/11 0.063s } 21. Bxc4 { +77/9 0.062s } 21... Bxf3 { +8/10 0.062s } 22. gxf3 { +86/10 0.062s } 22... Nbd7 { -5/9 0.062s } 23. Bb5 { +67/9 0.063s } 23... Nc5 { -8/9 0.062s } 24. Ra3 { +80/9 0.063s } 24... Nce4 { +46/11 0.062s } 25. Qb2 { -12/11 0.062s } 25... Ng5 { +38/10 0.063s } 26. c4 { -28/10 0.062s } 26... Nxh3+ { +137/10 0.063s } 27. Kf1 { -52/11 0.062s } 27... Qb8 { +107/9 0.062s } 28. Rad3 { -69/10 0.063s } 28... Qh2 { +226/10 0.062s } 29. Ke1 { -150/10 0.063s } 29... Rf8 { +248/10 0.062s } 30. Qd4 { -130/9 0.062s } 30... Nf4 { +202/9 0.063s } 31. Ra3 { -111/10 0.062s } 31... e5 { +201/9 0.063s } 32. Qb6 { -158/10 0.062s } 32... Ne6 { +206/9 0.062s } 33. Qxa5 { -138/10 0.062s } 33... Nd4 { +208/9 0.063s } 34. Rxd4 { -155/10 0.062s } 34... exd4 { +215/9 0.063s } 35. Ke2 { -177/8 0.062s } 35... Nh5 { +260/9 0.062s } 36. Kd1 { -206/10 0.063s } 36... Nf4 { +265/10 0.063s } 37. Qd2 { -197/9 0.063s } 37... d3 { +303/10 0.062s } 38. Qe1 { -221/10 0.062s } 38... Ng2 { +462/12 0.062s } 39. Qe4 { -381/10 0.062s } 39... Qg1+ { +447/11 0.063s } 40. Kd2 { -406/11 0.063s } 40... Qxf2+ { +490/11 0.062s } 41. Kc3 { -478/11 0.063s } 0-1
```
```
[Event "Tune.py"]
[Round "964"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "1-0"]
[BlackArgs "{}"]
[Termination "adjudication based on score"]
[WhiteArgs "{'PawnValueEn': 115, 'KnightValueOp': 289, 'BishopValueOp': 333, 'RookValueOp': 514, 'QueenValueOp': 1028}"]

1. e4 { book } 1... e6 { book } 2. d4 { book } 2... d5 { book } 3. Nc3 { book } 3... Bb4 { book } 4. e5 { book } 4... c5 { book } 5. Qg4 { book } 5... Ne7 { book } 6. Qxg7 { +53/9 0.05s } 6... Rg8 { +53/11 0.062s } 7. Qxh7 { +25/11 0.063s } 7... cxd4 { +23/11 0.062s } 8. a3 { +2/11 0.063s } 8... Qa5 { +49/11 0.062s } 9. axb4 { -45/10 0.062s } 9... Qxa1 { +46/11 0.063s } 10. Nce2 { -72/11 0.062s } 10... Bd7 { +45/11 0.063s } 11. Nf3 { -60/10 0.062s } 11... Bb5 { +56/11 0.062s } 12. Nfxd4 { -47/10 0.063s } 12... Bxe2 { +76/10 0.062s } 13. Nb3 { -8/12 0.063s } 13... Qa4 { +12/11 0.062s } 14. Bxe2 { +30/12 0.062s } 14... Qxb4+ { -28/11 0.063s } 15. Bd2 { +74/13 0.062s } 15... Qe4 { -54/12 0.063s } 16. Qxe4 { +42/12 0.062s } 16... dxe4 { -35/11 0.062s } 17. Nc5 { +31/12 0.063s } 17... Nbc6 { -43/11 0.062s } 18. Nxe4 { +46/11 0.063s } 18... Rxg2 { -14/10 0.062s } 19. Nf6+ { +54/10 0.062s } 19... Kd8 { -88/11 0.063s } 20. Bf3 { +82/11 0.062s } 20... Rg6 { -77/10 0.063s } 21. h4 { +84/10 0.062s } 21... Nxe5 { -31/11 0.062s } 22. Bxb7 { +132/12 0.063s } 22... Nc4 { -159/11 0.062s } 23. Bxa8 { +181/12 0.063s } 23... Nxd2 { -171/11 0.062s } 24. Kxd2 { +188/12 0.062s } 24... Rxf6 { -179/11 0.063s } 25. h5 { +202/11 0.062s } 25... Rxf2+ { -189/10 0.063s } 26. Kd3 { +213/11 0.062s } 26... a5 { -219/11 0.062s } 27. h6 { +251/10 0.062s } 27... Rf4 { -283/10 0.062s } 28. h7 { +278/10 0.063s } 28... Ng6 { -298/11 0.062s } 29. h8=Q+ { +261/11 0.063s } 29... Nxh8 { -280/10 0.062s } 30. Rxh8+ { +259/11 0.062s } 30... Ke7 { -287/11 0.063s } 31. b3 { +272/10 0.063s } 31... a4 { -261/10 0.063s } 32. bxa4 { +249/9 0.062s } 32... Rxa4 { -278/11 0.062s } 33. Bc6 { +252/11 0.063s } 33... Ra2 { -277/10 0.062s } 34. Bb5 { +246/11 0.063s } 34... Kd6 { -276/11 0.062s } 35. c4 { +251/11 0.062s } 35... Kc5 { -281/8 0.063s } 36. Rc8+ { +306/11 0.062s } 36... Kd6 { -341/11 0.063s } 37. c5+ { +324/11 0.062s } 37... Ke5 { -345/11 0.062s } 38. c6 { +416/12 0.063s } 38... Ra7 { -384/10 0.062s } 1-0
```