### PR TITLE
Add adjudication option

### DIFF
--- a/tools/tune.py
+++ b/tools/tune.py
@@ -87,10 +87,11 @@ group = parser.add_argument_group('Adjudication options')
 group.add_argument('-win-adj', nargs='*',
                    help='Adjudicate won game. Usage: '
                    '-win-adj count=4 score=400 '
-                   'If there are 4 moves from white that are 400 or more '
-                   'and there are 4 moves from black that are -400 or less '
-                   'then that game will be adjudicated to a win for white. '
-                   'When the situation is reversed black would win. '
+                   'If the last 4 successive moves of white had a score of '
+                   '400 cp or more and the last 4 successive moves of black '
+                   'had a score of -400 or less then that game will be '
+                   'adjudicated to a win for white. When the situation is '
+                   'reversed black would win. '
                    f'Default values: count=4, score={Arena.MATE_SCORE}')
 
 

--- a/tools/tune.py
+++ b/tools/tune.py
@@ -267,14 +267,35 @@ def summarize(opt, samples):
 async def main():
     args = parser.parse_args()
     
-    # Won game adjudication
+    if args.debug:
+        if args.debug == sys.stdout:
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig(level=logging.DEBUG, filename=args.debug, filemode='w')
+    
+    # Do not run the tuner if something is wrong with the adjudication option
+    # that is set by the user. These options could be critical in tuning.
     win_adj_count, win_adj_score = 4, Arena.MATE_SCORE
     if args.win_adj:
         for n in args.win_adj:
             if 'count' in n:
-                win_adj_count = int(n.split('=')[1])
+                try:
+                    win_adj_count = int(n.split('=')[1])
+                except (IndexError, ValueError):
+                    logging.exception('Error in win adjudication count option.')
+                    raise
+                except Exception:
+                    logging.exception('Unexpected exception in win-adj count.')
+                    raise
             elif 'score' in n:
-                win_adj_score = int(n.split('=')[1])
+                try:
+                    win_adj_score = int(n.split('=')[1])
+                except (IndexError, ValueError):
+                    logging.exception('Error in win adjudication score option.')
+                    raise
+                except Exception:
+                    logging.exception('Unexpected exception in win-adj score.')
+                    raise
 
     book = []
     if args.book:
@@ -283,12 +304,6 @@ async def main():
     if not book:
         book.append(chess.Board())
         print('No book. Starting every game from initial position.')
-
-    if args.debug:
-        if args.debug == sys.stdout:
-            logging.basicConfig(level=logging.DEBUG)
-        else:
-            logging.basicConfig(level=logging.DEBUG, filename=args.debug, filemode='w')
 
     print('Loading engines')
     conf = load_conf(args.conf)


### PR DESCRIPTION
tune.py -h
```
...
Adjudication options:
  -win-adj [WIN_ADJ [WIN_ADJ ...]]
                        Adjudicate won game. Usage: -win-adj count=4 score=400
                        If the last 4 successive moves of white had a score of
                        400 cp or more and the last 4 successive moves of
                        black had a score of -400 or less then that game will
                        be adjudicated to a win for white. When the situation
                        is reversed black would win. Default values: count=4,
                        score=32767

```
Example:
`-win-adj count=6 score=500`
```
[Event "Tune.py"]
[Round "5"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "0-1"]
[BlackArgs "{'PawnValueEn': 150, 'KnightValueOp': 321, 'BishopValueOp': 330, 'RookValueOp': 499, 'QueenValueOp': 972}"]
[Termination "adjudication based on score"]
[WhiteArgs "{}"]

1. c4 { book } 1... Nf6 { book } 2. Nc3 { book } 2... g6 { book } 3. d4 { book } 3... Bg7 { book } 4. e4 { book } 4... d6 { book } 5. f3 { book } 5... O-O { book } 6. Kf2 { -20/8 0.062s } 6... e5 { +24/8 0.063s } 7. dxe5 { +2/11 0.062s } 7... dxe5 { -2/11 0.062s } 8. Qxd8 { -1/12 0.063s } 8... Rxd8 { +12/12 0.062s } 9. Nd5 { +1/12 0.063s } 9... Nxd5 { +3/11 0.062s } 10. cxd5 { -13/11 0.062s } 10... c6 { +5/11 0.063s } 11. Bc4 { +3/10 0.062s } 11... Nd7 { -15/11 0.063s } 12. dxc6 { +2/11 0.062s } 12... bxc6 { -29/12 0.062s } 13. Be3 { +17/10 0.053s } 13... Nb6 { -38/11 0.062s } 14. Bb3 { +2/11 0.062s } 14... Ba6 { -27/11 0.063s } 15. Rc1 { +25/12 0.062s } 15... Rac8 { -22/11 0.063s } 16. Ne2 { +36/9 0.062s } 16... c5 { -53/10 0.062s } 17. Rhd1 { +67/11 0.063s } 17... Rxd1 { -76/11 0.062s } 18. Rxd1 { +79/11 0.05s } 18... Bf6 { -79/10 0.05s } 19. Nc3 { +76/10 0.062s } 19... Kg7 { -75/10 0.062s } 20. g3 { +59/10 0.063s } 20... h5 { -64/9 0.063s } 21. Nd5 { +72/10 0.062s } 21... Bd8 { -67/11 0.062s } 22. Rc1 { +60/9 0.063s } 22... c4 { -60/10 0.062s } 23. Bd1 { +55/10 0.063s } 23... Nxd5 { -37/12 0.062s } 24. exd5 { +28/12 0.062s } 24... Bb6 { -19/12 0.063s } 25. f4 { +29/10 0.062s } 25... Rd8 { -18/9 0.063s } 26. Bf3 { +29/11 0.062s } 26... Bd4 { -35/10 0.062s } 27. fxe5 { +45/9 0.063s } 27... Bxb2 { +19/11 0.062s } 28. Bg5 { -1/11 0.063s } 28... Rb8 { +37/12 0.062s } 29. Bf6+ { -3/11 0.062s } 29... Kh6 { +30/11 0.063s } 30. Rd1 { -1/12 0.062s } 30... Bb5 { -20/10 0.063s } 31. Ke3 { -10/10 0.062s } 31... c3 { +80/12 0.062s } 32. e6 { -152/10 0.063s } 32... fxe6 { +147/10 0.062s } 33. Re1 { -110/11 0.063s } 33... exd5 { +178/10 0.062s } 34. Bxd5 { -149/10 0.062s } 34... Re8+ { +212/12 0.063s } 35. Be4 { -148/13 0.062s } 35... a5 { +205/11 0.063s } 36. h3 { -151/11 0.062s } 36... Bc4 { +204/11 0.062s } 37. g4 { -121/10 0.063s } 37... Bxa2 { +209/12 0.062s } 38. Kd3 { -187/9 0.063s } 38... Rc8 { +158/10 0.062s } 39. gxh5 { -58/9 0.062s } 39... Bb1+ { +273/12 0.063s } 40. Rxb1 { -203/13 0.062s } 40... c2 { +300/14 0.063s } 41. Re1 { -242/14 0.062s } 41... Bxf6 { +313/15 0.062s } 42. Rc1 { -208/14 0.063s } 42... Rc3+ { +328/14 0.062s } 43. Kd2 { -244/15 0.05s } 43... Rxh3 { +313/15 0.063s } 44. Rxc2 { -261/14 0.064s } 44... Rh2+ { +326/14 0.063s } 45. Ke3 { -264/15 0.062s } 45... Rxc2 { +343/15 0.062s } 46. Bxc2 { -240/17 0.063s } 46... gxh5 { +342/18 0.062s } 47. Kf4 { -240/19 0.063s } 47... h4 { +342/16 0.062s } 48. Kg4 { -229/22 0.062s } 48... Kg7 { +325/21 0.063s } 49. Bb3 { -237/18 0.062s } 49... Kf8 { +334/20 0.063s } 50. Bc2 { -237/19 0.062s } 50... Kf7 { +332/20 0.062s } 51. Bb3+ { -234/20 0.063s } 51... Ke7 { +334/21 0.062s } 52. Bc2 { -227/20 0.063s } 52... Ke6 { +332/20 0.062s } 53. Bf5+ { -227/20 0.062s } 53... Kd6 { +330/21 0.063s } 54. Bc2 { -223/19 0.062s } 54... Kc5 { +334/19 0.063s } 55. Ba4 { -223/19 0.062s } 55... Be7 { +328/19 0.062s } 56. Bd7 { -224/20 0.063s } 56... Kc4 { +323/18 0.062s } 57. Bc6 { -220/20 0.063s } 57... Bf6 { +319/19 0.062s } 58. Bd7 { -223/19 0.062s } 58... Kd5 { +323/19 0.063s } 59. Bb5 { -219/20 0.062s } 59... Kd4 { +319/20 0.063s } 60. Be8 { -214/18 0.062s } 60... Be7 { +317/19 0.062s } 61. Bb5 { -214/19 0.063s } 61... Ke3 { +317/20 0.062s } 62. Ba4 { -214/19 0.063s } 62... Kd3 { +319/19 0.062s } 63. Bd7 { -216/18 0.062s } 63... Ke4 { +320/20 0.063s } 64. Bc6+ { -212/20 0.062s } 64... Ke5 { +324/21 0.063s } 65. Bd7 { -216/20 0.062s } 65... Kd6 { +327/20 0.062s } 66. Bb5 { -214/19 0.063s } 66... Kd5 { +328/22 0.062s } 67. Ba4 { -212/20 0.063s } 67... Bd8 { +319/21 0.062s } 68. Bd7 { -212/19 0.062s } 68... Ke4 { +315/19 0.063s } 69. Bc6+ { -218/18 0.062s } 69... Kd3 { +327/19 0.063s } 70. Be8 { -212/18 0.062s } 70... Ke3 { +329/18 0.062s } 71. Bb5 { -214/20 0.063s } 71... Kf2 { +317/21 0.062s } 72. Bc6 { -214/20 0.063s } 72... Bf6 { +319/21 0.062s } 73. Kf5 { -214/17 0.062s } 73... h3 { +719/13 0.063s } 74. Kxf6 { -479/12 0.062s } 74... h2 { +754/15 0.063s } 75. Ke5 { -751/13 0.062s } 75... Ke3 { +783/16 0.062s } 76. Bh1 { -781/15 0.063s } 76... a4 { +802/16 0.062s } 77. Kd6 { -800/16 0.063s } 77... a3 { +818/16 0.062s } 78. Bd5 { -811/14 0.062s } 78... Kd4 { +1162/14 0.063s } 79. Kc6 { -1173/12 0.062s } 79... a2 { +1192/15 0.063s } 80. Kd6 { -1191/16 0.062s } 0-1
```
```
[Event "Tune.py"]
[Round "6"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "1-0"]
[BlackArgs "{}"]
[Termination "adjudication based on score"]
[WhiteArgs "{'PawnValueEn': 96, 'KnightValueOp': 327, 'BishopValueOp': 319, 'RookValueOp': 528, 'QueenValueOp': 1029}"]

1. d4 { book } 1... e6 { book } 2. c4 { book } 2... Bb4+ { book } 3. Bd2 { book } 3... Bxd2+ { book } 4. Nxd2 { book } 4... d6 { book } 5. Ngf3 { book } 5... Qe7 { book } 6. e3 { +115/9 0.063s } 6... Nf6 { -80/10 0.063s } 7. Bd3 { +107/9 0.062s } 7... e5 { -70/9 0.062s } 8. Qa4+ { +50/8 0.063s } 8... Bd7 { -31/11 0.062s } 9. Qc2 { +32/11 0.063s } 9... Nc6 { +15/11 0.062s } 10. dxe5 { -25/10 0.062s } 10... Nb4 { +46/13 0.063s } 11. Qc3 { -34/12 0.062s } 11... Nxd3+ { +18/12 0.063s } 12. Qxd3 { -11/12 0.062s } 12... dxe5 { +38/12 0.062s } 13. Qc3 { -29/12 0.063s } 13... e4 { +30/12 0.062s } 14. Ne5 { -28/11 0.063s } 14... O-O-O { +33/11 0.062s } 15. O-O { -36/10 0.062s } 15... Rhe8 { +37/10 0.063s } 16. Nxd7 { -14/11 0.062s } 16... Qxd7 { +22/10 0.063s } 17. Rfd1 { -18/10 0.062s } 17... h5 { +29/9 0.062s } 18. Qc1 { -22/9 0.063s } 18... Kb8 { +44/10 0.062s } 19. Nb3 { -28/11 0.063s } 19... Qf5 { +25/11 0.062s } 20. Qc2 { -35/10 0.062s } 20... c5 { +24/10 0.063s } 21. f3 { -44/10 0.062s } 21... Qe5 { +54/11 0.063s } 22. Qf2 { -71/10 0.062s } 22... exf3 { +68/10 0.062s } 23. gxf3 { -58/10 0.063s } 23... b6 { +89/10 0.062s } 24. e4 { -89/10 0.063s } 24... g5 { +59/10 0.062s } 25. Qg3 { -52/12 0.062s } 25... Qxg3+ { +46/11 0.063s } 26. hxg3 { -51/13 0.062s } 26... Nd7 { +52/11 0.063s } 27. Rd5 { -33/11 0.062s } 27... g4 { +50/11 0.062s } 28. fxg4 { -51/12 0.063s } 28... hxg4 { +35/12 0.062s } 29. Rf1 { -32/12 0.063s } 29... Ne5 { +30/13 0.062s } 30. Nd2 { -27/13 0.062s } 30... Kc7 { +38/12 0.063s } 31. Kg2 { -37/11 0.062s } 31... Re6 { +40/12 0.063s } 32. Rh1 { -47/10 0.062s } 32... Rde8 { +39/12 0.062s } 33. a3 { -28/11 0.063s } 33... a5 { +31/12 0.062s } 34. b3 { -27/13 0.063s } 34... f6 { +27/11 0.062s } 35. Rh7+ { -28/13 0.062s } 35... R6e7 { +33/12 0.063s } 36. Rh1 { -31/11 0.062s } 36... Rd8 { +31/11 0.063s } 37. Rh6 { -38/10 0.062s } 37... Rf7 { +27/11 0.062s } 38. a4 { +6/11 0.063s } 38... Re8 { +32/12 0.062s } 39. Nb1 { +39/13 0.063s } 39... Nf3 { -31/10 0.062s } 40. Nc3 { +22/11 0.062s } 40... Nd4 { -9/10 0.063s } 41. Rg6 { +76/11 0.062s } 41... Re5 { -60/10 0.063s } 42. Rxe5 { +64/11 0.062s } 42... fxe5 { -76/13 0.062s } 43. Nd5+ { +98/13 0.063s } 43... Kc8 { -76/13 0.062s } 44. Nxb6+ { +95/12 0.063s } 44... Kb8 { -97/13 0.062s } 45. Rxg4 { +118/13 0.062s } 45... Nxb3 { -120/14 0.063s } 46. Rg5 { +118/13 0.062s } 46... Nd2 { -112/13 0.063s } 47. Rxe5 { +119/14 0.062s } 47... Kb7 { -140/13 0.062s } 48. Re6 { +144/12 0.063s } 48... Rg7 { -132/12 0.062s } 49. Kf2 { +164/13 0.063s } 49... Nxe4+ { -140/12 0.062s } 50. Rxe4 { +155/14 0.062s } 50... Kxb6 { -137/13 0.063s } 51. g4 { +151/14 0.062s } 51... Kc7 { -173/13 0.063s } 52. Kg3 { +157/15 0.062s } 52... Kd6 { -171/13 0.062s } 53. Re8 { +171/15 0.063s } 53... Rb7 { -182/12 0.062s } 54. g5 { +177/14 0.063s } 54... Rb1 { -161/13 0.062s } 55. Kf2 { +185/14 0.062s } 55... Rb2+ { -178/12 0.063s } 56. Kf3 { +200/15 0.062s } 56... Rb1 { -179/14 0.063s } 57. Ra8 { +196/13 0.062s } 57... Ke5 { -169/13 0.062s } 58. Rxa5 { +184/14 0.063s } 58... Kd4 { -197/14 0.062s } 59. g6 { +205/13 0.063s } 59... Kxc4 { -201/13 0.062s } 60. Rb5 { +211/13 0.062s } 60... Rg1 { -241/12 0.063s } 61. Rb6 { +280/12 0.062s } 61... Re1 { -278/11 0.063s } 62. g7 { +345/13 0.062s } 62... Re8 { -378/15 0.062s } 63. a5 { +572/14 0.063s } 63... Rg8 { -474/16 0.062s } 64. Rb7 { +639/15 0.063s } 64... Kd5 { -493/16 0.062s } 65. a6 { +1035/11 0.062s } 65... Kc6 { -855/10 0.063s } 66. Rf7 { +1176/12 0.062s } 66... Kd5 { -1178/12 0.063s } 67. a7 { +1223/14 0.062s } 67... Ke6 { -1206/14 0.062s } 68. Rf8 { +1232/14 0.063s } 68... Rxg7 { -1227/13 0.062s } 69. a8=Q { +1230/12 0.063s } 69... Rf7+ { -1230/12 0.062s } 70. Rxf7 { +1234/12 0.062s } 70... Kxf7 { -1230/12 0.063s } 1-0
```
```
[Event "Tune.py"]
[Round "8"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "0-1"]
[BlackArgs "{}"]
[Termination "adjudication based on score"]
[WhiteArgs "{'PawnValueEn': 150, 'KnightValueOp': 301, 'BishopValueOp': 317, 'RookValueOp': 526, 'QueenValueOp': 978}"]

1. d4 { book } 1... d5 { book } 2. c4 { book } 2... dxc4 { book } 3. e4 { book } 3... Nc6 { book } 4. Nf3 { book } 4... Bg4 { book } 5. d5 { book } 5... Ne5 { book } 6. Bf4 { +63/9 0.063s } 6... Ng6 { -44/9 0.063s } 7. Bg3 { +36/9 0.062s } 7... e5 { -36/9 0.062s } 8. Bxc4 { +39/8 0.063s } 8... Nf6 { -42/9 0.062s } 9. Nc3 { +56/9 0.063s } 9... a6 { -22/9 0.062s } 10. h3 { +46/10 0.062s } 10... Bxf3 { -26/10 0.063s } 11. Qxf3 { +42/11 0.062s } 11... b5 { -39/12 0.063s } 12. Nxb5 { +27/11 0.062s } 12... axb5 { -9/10 0.062s } 13. Bxb5+ { +7/11 0.063s } 13... Nd7 { +18/11 0.062s } 14. O-O { +35/11 0.063s } 14... Bc5 { +8/10 0.062s } 15. Qf5 { +63/11 0.062s } 15... Ra5 { -7/10 0.063s } 16. Bc6 { +63/9 0.062s } 16... Bd4 { +35/10 0.063s } 17. Rfb1 { +22/10 0.062s } 17... Ra6 { +58/10 0.062s } 18. a4 { -21/9 0.063s } 18... Ne7 { +101/12 0.062s } 19. Qg4 { -56/10 0.063s } 19... Nxc6 { +185/11 0.062s } 20. dxc6 { -126/11 0.062s } 20... Nf6 { +219/12 0.063s } 21. Qe2 { -154/10 0.062s } 21... Qa8 { +235/11 0.063s } 22. Rc1 { -190/10 0.062s } 22... O-O { +242/11 0.062s } 23. Bh4 { -223/11 0.063s } 23... Rb8 { +262/11 0.062s } 24. Bxf6 { -195/9 0.063s } 24... gxf6 { +204/11 0.062s } 25. Rab1 { -197/11 0.062s } 25... Rxc6 { +196/11 0.063s } 26. Rxc6 { -193/12 0.062s } 26... Qxc6 { +232/10 0.063s } 27. b3 { -177/10 0.062s } 27... Kf8 { +250/10 0.062s } 28. Qd3 { -192/11 0.063s } 28... Qc3 { +250/10 0.062s } 29. Qxc3 { -176/11 0.063s } 29... Bxc3 { +262/12 0.062s } 30. Kh2 { -295/11 0.062s } 30... Ke7 { +332/12 0.063s } 31. g3 { -351/12 0.062s } 31... c5 { +361/13 0.063s } 32. a5 { -359/14 0.062s } 32... Bxa5 { +385/14 0.062s } 33. Rc1 { -356/15 0.063s } 33... Rxb3 { +367/13 0.062s } 34. Rxc5 { -353/15 0.063s } 34... Bb6 { +374/14 0.062s } 35. Rc2 { -358/14 0.062s } 35... h5 { +378/13 0.063s } 36. Kg2 { -357/15 0.062s } 36... Rb4 { +378/13 0.063s } 37. f3 { -345/13 0.062s } 37... Rb1 { +370/13 0.062s } 38. h4 { -356/13 0.063s } 38... Kd6 { +366/14 0.062s } 39. Ra2 { -352/13 0.063s } 39... Bd4 { +365/15 0.062s } 40. Ra6+ { -351/14 0.062s } 40... Ke7 { +366/14 0.063s } 41. Ra8 { -346/14 0.062s } 41... Rg1+ { +367/13 0.063s } 42. Kh2 { -346/14 0.062s } 42... f5 { +397/13 0.062s } 43. exf5 { -346/13 0.063s } 43... Kf6 { +412/13 0.062s } 44. Rh8 { -366/13 0.063s } 44... Rf1 { +429/13 0.062s } 45. Rh6+ { -383/12 0.062s } 45... Kg7 { +448/15 0.063s } 46. Rxh5 { -430/13 0.062s } 46... Rxf3 { +498/13 0.063s } 47. Kh3 { -431/11 0.062s } 47... e4 { +502/15 0.062s } 48. Rg5+ { -500/13 0.063s } 48... Kf6 { +562/15 0.062s } 49. Rg4 { -500/13 0.063s } 49... Kxf5 { +579/14 0.062s } 50. Rg5+ { -618/13 0.062s } 50... Ke6 { +622/15 0.063s } 51. Rb5 { -637/12 0.062s } 51... Be5 { +651/13 0.063s } 52. Rb6+ { -696/13 0.062s } 52... Kf5 { +685/13 0.062s } 53. Kg2 { -704/14 0.063s } 0-1
```
```
[Event "Tune.py"]
[Round "11"]
[White "Deuterium v2019.2.37.52"]
[Black "Deuterium v2019.2.37.52"]
[Result "0-1"]
[BlackArgs "{'PawnValueEn': 105, 'KnightValueOp': 285, 'BishopValueOp': 291, 'RookValueOp': 508, 'QueenValueOp': 975}"]
[Termination "adjudication based on score"]
[WhiteArgs "{}"]

1. Nf3 { book } 1... Nf6 { book } 2. c4 { book } 2... g6 { book } 3. Nc3 { book } 3... d5 { book } 4. cxd5 { book } 4... Nxd5 { book } 5. h4 { book } 5... Bg7 { book } 6. e4 { +82/10 0.062s } 6... Nxc3 { -66/9 0.063s } 7. bxc3 { +92/9 0.062s } 7... O-O { -39/7 0.063s } 8. d4 { +80/9 0.062s } 8... Bg4 { -20/8 0.062s } 9. Rb1 { +54/8 0.063s } 9... c5 { +3/9 0.062s } 10. h5 { +3/9 0.063s } 10... Bxh5 { +22/9 0.062s } 11. Rxb7 { +2/8 0.062s } 11... cxd4 { +86/10 0.063s } 12. Rxh5 { -20/10 0.062s } 12... gxh5 { +66/12 0.063s } 13. Nxd4 { -34/11 0.062s } 13... e6 { +90/9 0.062s } 14. Ba3 { +65/9 0.063s } 14... Qc8 { +73/11 0.062s } 15. Rb3 { -30/11 0.063s } 15... Rd8 { +114/10 0.062s } 16. Qxh5 { -26/10 0.062s } 16... Nc6 { +113/11 0.063s } 17. Bc5 { -70/8 0.062s } 17... Na5 { +178/11 0.063s } 18. Rb5 { -81/10 0.062s } 18... Nb7 { +287/10 0.062s } 19. Bd3 { -220/10 0.063s } 19... f5 { +202/10 0.062s } 20. Rxb7 { -193/9 0.063s } 20... Qxb7 { +233/11 0.062s } 21. exf5 { -131/10 0.062s } 21... Qd5 { +331/11 0.063s } 22. Qg5 { -157/8 0.062s } 22... Qxc5 { +431/12 0.063s } 23. Qxg7+ { -445/12 0.062s } 23... Kxg7 { +161/2 0.0s } 24. Nxe6+ { -451/15 0.062s } 24... Kh6 { +469/14 0.063s } 25. Nxc5 { -471/16 0.062s } 25... Rac8 { +487/15 0.063s } 26. Ne4 { -479/13 0.062s } 26... Rxd3 { +465/14 0.062s } 27. f3 { -478/14 0.063s } 27... Rd5 { +497/13 0.062s } 28. g4 { -504/14 0.063s } 28... Ra5 { +499/14 0.062s } 29. Ke2 { -505/14 0.062s } 29... Rxa2+ { +529/12 0.063s } 30. Ke3 { -527/12 0.062s } 30... a5 { +567/12 0.063s } 31. g5+ { -526/10 0.062s } 31... Kg7 { +604/12 0.062s } 32. Kd4 { -595/11 0.063s } 32... a4 { +668/11 0.062s } 33. c4 { -675/9 0.063s } 33... a3 { +731/11 0.062s } 34. f6+ { -870/10 0.062s } 34... Kg6 { +898/12 0.063s } 0-1
```

Using
`-win-adj score=700`
is also possible, count default value of 4 will be used.